### PR TITLE
Enable Trusted Publishing for NuGet package

### DIFF
--- a/.github/workflows/publish-nuget-package.yml
+++ b/.github/workflows/publish-nuget-package.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # enable GitHub OIDC token issuance
 
 jobs:
   publish-email-service-nuget-package:
@@ -31,10 +32,15 @@ jobs:
       - name: Build and pack
         run: dotnet build ./src/EmailService/EmailService.csproj --configuration Release
 
+      # Get a short-lived NuGet API key
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: NuGet Push
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push .artifacts/EmailService/bin/Release/*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push .artifacts/EmailService/bin/Release/*.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Create GitHub Release
         uses: anton-yurchenko/git-release@ec9c5b5c36b27eaffc628785b9183eae54601200


### PR DESCRIPTION
Updated the NuGet package publishing workflow to use Trusted Publishing

https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing