### PR TITLE
Enable leaving sender email null to use default

### DIFF
--- a/src/EmailService/Message.cs
+++ b/src/EmailService/Message.cs
@@ -31,7 +31,7 @@ public record Message
         if (!recipients.AreAllValid())
             throw new ArgumentException("Recipient list includes invalid emails.", nameof(recipients));
 
-        if (!senderEmail.IsValid())
+        if (senderEmail != null && !senderEmail.IsValid())
             throw new ArgumentException("Sender email is invalid.", nameof(senderEmail));
 
         if (copyRecipients != null && recipients.Count > 0 && !copyRecipients.AreAllValid())

--- a/tests/EmailService.Tests/CreateMessageTests.cs
+++ b/tests/EmailService.Tests/CreateMessageTests.cs
@@ -5,6 +5,7 @@ namespace EmailService.Tests;
 public class CreateMessageTests
 {
     private const string ValidEmail = "a@example.com";
+    private const string InvalidEmail = "a.example.com";
 
     [Test]
     public void Create_WithEmptySubject_Throws()
@@ -12,6 +13,30 @@ public class CreateMessageTests
         var func = () => Message.Create(subject: "", recipients: [ValidEmail], senderEmail: ValidEmail, textBody: "d",
             htmlBody: null);
         func.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void Create_WithEmptySender_Throws()
+    {
+        var func = () => Message.Create(subject: "a", recipients: [ValidEmail], senderEmail: "", textBody: "d",
+            htmlBody: null);
+        func.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void Create_WithInvalidSender_Throws()
+    {
+        var func = () => Message.Create(subject: "a", recipients: [ValidEmail], senderEmail: InvalidEmail,
+            textBody: "d", htmlBody: null);
+        func.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void Create_WithNullSender_DoesNotThrow()
+    {
+        var func = () => Message.Create(subject: "a", recipients: [ValidEmail], senderEmail: null, textBody: "d",
+            htmlBody: null);
+        func.Should().NotThrow();
     }
 
     [Test]
@@ -34,8 +59,8 @@ public class CreateMessageTests
     [Test]
     public void Create_WithInvalidRecipient_Throws()
     {
-        var func = () => Message.Create(subject: "a", recipients: ["a.b.c"], senderEmail: ValidEmail, textBody: "d",
-            htmlBody: null);
+        var func = () => Message.Create(subject: "a", recipients: [InvalidEmail], senderEmail: ValidEmail,
+            textBody: "d", htmlBody: null);
         func.Should().Throw<ArgumentException>();
     }
 
@@ -72,7 +97,7 @@ public class CreateMessageTests
     }
 
     [Test]
-    public void Create_WithInvalidCopyRecipient_Throws()
+    public void Create_WithCopyRecipient_Throws()
     {
         var func = () => Message.Create(subject: "a", recipients: [ValidEmail], senderEmail: ValidEmail, textBody: "d",
             htmlBody: null, copyRecipients: ["a.b.c"]);


### PR DESCRIPTION
If the client application leaves the sender as null when generating a message, the message should use the default sender. (That's why it's a default.) But the create message method included a validator that threw an exception for a null sender. This PR fixes that. (An exception is still thrown for an empty string sender.)